### PR TITLE
Replace deprecated 'setting_getbool' with 'settings:get_bool'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -33,7 +33,7 @@ unifieddyes = {}
 unifieddyes.last_used_dye = {}
 unifieddyes.last_dyed_node = {}
 
-local creative_mode = minetest.setting_getbool("creative_mode")
+local creative_mode = minetest.settings:get_bool("creative_mode")
 
 -- Boilerplate to support localized strings if intllib mod is installed.
 local S


### PR DESCRIPTION
May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267