### PR TITLE
Fix issue with coloredwood

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -179,7 +179,7 @@ function unifieddyes.recolor_on_place(pos, placer, itemstack, pointed_thing)
 			end
 
 			local paletteidx, hue = unifieddyes.getpaletteidx(lastdye, palette_type)
-			if palette_type == true then newname = string.gsub(newname, "_grey", "_"..unifieddyes.HUES[hue]) end
+			if palette_type then newname = string.gsub(newname, "_grey", "_"..unifieddyes.HUES[hue]) end
 
 			minetest.set_node(pos, { name = newname, param2 = oldfdir + paletteidx })
 


### PR DESCRIPTION
```
2017-09-30 17:05:31: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'moreblocks' in callback item_OnPlace(): ...n64\bin\..\games\Colored_Block\mods\unifieddyes\init.lua:182: attempt to concatenate a nil value
2017-09-30 17:05:31: ERROR[Main]: stack traceback:
2017-09-30 17:05:31: ERROR[Main]: 	...n64\bin\..\games\Colored_Block\mods\unifieddyes\init.lua:182: in function 'recolor_on_place'
2017-09-30 17:05:31: ERROR[Main]: 	...n64\bin\..\games\Colored_Block\mods\coloredwood\init.lua:215: in function 'after_place_node'
2017-09-30 17:05:31: ERROR[Main]: 	E:\Jeux\minetest-0.4.16-win64\bin\..\builtin\game\item.lua:307: in function <E:\Jeux\minetest-0.4.16-win64\bin\..\builtin\game\item.lua:208>
```

Issue with colored_wood, moreblocks.
If use autocolored mode and one block cut with circulaw saw + shift , i have issue